### PR TITLE
Give unlabelled identity QC a reserved toolbar pane

### DIFF
--- a/src/manic/resources/integration_window.qss
+++ b/src/manic/resources/integration_window.qss
@@ -55,8 +55,11 @@ QGroupBox#integrationWindow QLineEdit {
     border: 1px solid #cccccc;
     border-radius: 2px;
     padding: 0px;
-    min-width: 70px;  /* Set consistent width */
-    max-width: 70px;  /* Prevent stretching beyond this */
+    min-width: 0;
+}
+
+QGroupBox#integrationWindow QPushButton {
+    min-width: 0;
 }
 
 /* Styling for "Apply" buttons - only within integration window */
@@ -78,19 +81,19 @@ QGroupBox#integrationWindow QPushButton#ApplyButton:pressed {
 
 /* Styling for "Restore" buttons - only within integration window */
 QGroupBox#integrationWindow QPushButton#RestoreButton {
-    background-color: #dc3545;
-    color: white;
+    background-color: #f1f3f5;
+    color: #334155;
     border: none;
     padding: 4px;
     border-radius: 6px 12px;
 }
 
 QGroupBox#integrationWindow QPushButton#RestoreButton:hover {
-    background-color: #bb2d3b;
+    background-color: #e2e8f0;
 }
 
 QGroupBox#integrationWindow QPushButton#RestoreButton:pressed {
-    background-color: #b02a37;
+    background-color: #cbd5e1;
 }
 
 

--- a/src/manic/resources/integration_window.qss
+++ b/src/manic/resources/integration_window.qss
@@ -62,7 +62,6 @@ QGroupBox#integrationWindow QPushButton {
     min-width: 0;
 }
 
-/* Styling for "Apply" buttons - only within integration window */
 QGroupBox#integrationWindow QPushButton#ApplyButton {
     background-color: #0d6efd;
     color: white;
@@ -79,7 +78,6 @@ QGroupBox#integrationWindow QPushButton#ApplyButton:pressed {
     background-color: #0a58ca;
 }
 
-/* Styling for "Restore" buttons - only within integration window */
 QGroupBox#integrationWindow QPushButton#RestoreButton {
     background-color: #f1f3f5;
     color: #334155;

--- a/src/manic/resources/style.qss
+++ b/src/manic/resources/style.qss
@@ -95,6 +95,20 @@ QWidget#toolbar QScrollBar::sub-page:vertical {
     background: none;
 }
 
+QWidget#toolbar QSplitter::handle:vertical {
+    background-color: #e2e8f0;
+    height: 3px;
+}
+
+QWidget#toolbar QLabel#unlabelledLoadStatus,
+QWidget#toolbar QLabel#unlabelledIsStatus,
+QWidget#toolbar QLabel#unlabelledIonStatus {
+    color: #64748b;
+    font-size: 11px;
+    background-color: transparent;
+    border: none;
+}
+
 /* Chart widget borders */
 QWidget#isotopologueRatioWidget, QWidget#totalAbundanceWidget {
     border: 1px solid #d0d0d0;

--- a/src/manic/ui/integration_window_widget.py
+++ b/src/manic/ui/integration_window_widget.py
@@ -10,6 +10,7 @@ from PySide6.QtWidgets import (
     QLineEdit,
     QMessageBox,
     QPushButton,
+    QSizePolicy,
     QVBoxLayout,
 )
 
@@ -246,59 +247,65 @@ class IntegrationWindow(QGroupBox):
 
     def _build_ui(self):
         layout = QVBoxLayout(self)
-        layout.setSpacing(10)
+        layout.setContentsMargins(6, 10, 6, 6)
+        layout.setSpacing(6)
 
-        # Integration parameter fields
+        fields_row = QHBoxLayout()
+        fields_row.setSpacing(6)
         for label_text, obj_name in [
-            ("Left Offset", "lo_input"),
+            ("Left", "lo_input"),
             ("tR", "tr_input"),
-            ("Right Offset", "ro_input"),
+            ("Right", "ro_input"),
         ]:
-            row = QHBoxLayout()
             lbl = QLabel(label_text)
             lbl.setStyleSheet("QLabel { background-color: white; border: none; }")
             edt = QLineEdit()
             edt.setObjectName(obj_name)
-            # Enable Enter key to trigger apply (same as clicking Apply button)
+            edt.setMinimumWidth(0)
+            edt.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
             edt.returnPressed.connect(self._on_apply_clicked)
-            row.addWidget(lbl)
-            row.addWidget(edt, 1)
-            layout.addLayout(row)
+            fields_row.addWidget(lbl)
+            fields_row.addWidget(edt, 1)
+        layout.addLayout(fields_row)
 
-        # Action buttons
-        button_row = QHBoxLayout()
+        actions_row = QHBoxLayout()
+        actions_row.setSpacing(6)
         self.apply_button = QPushButton("Apply")
         self.apply_button.setObjectName("ApplyButton")
         self.apply_button.clicked.connect(self._on_apply_clicked)
-        button_row.addWidget(self.apply_button)
+        actions_row.addWidget(self.apply_button)
 
         self.restore_button = QPushButton("Reset")
         self.restore_button.setObjectName("RestoreButton")
         self.restore_button.clicked.connect(self._on_restore_clicked)
-        button_row.addWidget(self.restore_button)
+        actions_row.addWidget(self.restore_button)
 
-        layout.addLayout(button_row)
-
-        # tR Window field for data regeneration
-        tr_window_row = QHBoxLayout()
         tr_window_lbl = QLabel("tR Window")
         tr_window_lbl.setStyleSheet("QLabel { background-color: white; border: none; }")
         self.tr_window_edit = QLineEdit()
         self.tr_window_edit.setObjectName("tr_window_input")
-        # Enable Enter key to trigger regeneration (same as clicking Update tR Window button)
+        self.tr_window_edit.setMinimumWidth(0)
+        self.tr_window_edit.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed
+        )
         self.tr_window_edit.returnPressed.connect(self._on_regenerate_clicked)
-        tr_window_row.addWidget(tr_window_lbl)
-        tr_window_row.addWidget(self.tr_window_edit, 1)
-        layout.addLayout(tr_window_row)
+        actions_row.addWidget(tr_window_lbl)
+        actions_row.addWidget(self.tr_window_edit, 1)
 
-        # Regeneration button
-        regen_button_row = QHBoxLayout()
-        self.regenerate_button = QPushButton("Update tR Window")
+        self.regenerate_button = QPushButton("Update")
         self.regenerate_button.setObjectName("RegenerateButton")
         self.regenerate_button.clicked.connect(self._on_regenerate_clicked)
-        regen_button_row.addWidget(self.regenerate_button)
+        actions_row.addWidget(self.regenerate_button)
 
-        layout.addLayout(regen_button_row)
+        for button in (
+            self.apply_button,
+            self.restore_button,
+            self.regenerate_button,
+        ):
+            button.setMinimumWidth(0)
+            button.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed)
+
+        layout.addLayout(actions_row)
 
     def _format_number(self, value: float, sig_figs: int = 4) -> str:
         """

--- a/src/manic/ui/left_toolbar.py
+++ b/src/manic/ui/left_toolbar.py
@@ -1,11 +1,16 @@
+from dataclasses import dataclass
 from typing import List
 
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
     QCheckBox,
     QFrame,
+    QGridLayout,
+    QHBoxLayout,
     QLabel,
     QScrollArea,
+    QSizePolicy,
+    QSplitter,
     QVBoxLayout,
     QWidget,
 )
@@ -24,31 +29,23 @@ from .targeted_qc_widget import TargetedQcWidget
 from .total_abundance_widget import TotalAbundanceWidget
 
 
+@dataclass(frozen=True, slots=True)
+class UnlabelledToolbarLayoutSpec:
+    list_max_height: int = 120
+    qc_min_height: int = 260
+    qc_split_share: float = 0.42
+    toolbar_min_width: int = 272
+
+
 class Toolbar(QWidget):
-    # Signal for the currently selected samples
     samples_selected = Signal(list)
-
-    # Signal for the currently selected compound
     compound_selected = Signal(str)
-
-    # Signal for when internal standard is selected
     internal_standard_selected = Signal(str)
-
-    # Signal for when compounds are deleted
     compounds_deleted = Signal(list)
-
-    # Signal for when compounds are restored
     compounds_restored = Signal(list)
-
-    # Signal for when samples are deleted
     samples_deleted = Signal(list)
-
-    # Signal for when samples are restored
     samples_restored = Signal(list)
-
-    # Signal emitted when baseline correction checkbox is toggled
-    baseline_correction_changed = Signal(str, bool)  # compound_name, enabled
-
+    baseline_correction_changed = Signal(str, bool)
     shared_y_scale_toggled = Signal(bool)
     targeted_trace_normalization_toggled = Signal(bool)
 
@@ -58,13 +55,215 @@ class Toolbar(QWidget):
     ):
         super().__init__()
         self.analysis_mode = AnalysisMode.coerce(analysis_mode)
-        self.setObjectName("toolbar")  # Required for CSS targeting
+        self.setObjectName("toolbar")
+        self._layout_spec = UnlabelledToolbarLayoutSpec()
+        self._unlabelled_sizes_applied = False
+        self.load_status_label = None
+        self.is_status_label = None
         self._build_ui()
         self._connect_signals()
 
     def _build_ui(self):
-        """Set up the toolbar layout and child widgets"""
-        # Container widget provides rounded border appearance
+        self.loaded_data = LoadedDataWidget()
+        self.standard = StandardIndicator()
+        self.sample_list = SampleListWidget()
+        self.compound_list = CompoundListWidget()
+        self.integration = IntegrationWindow(self.analysis_mode)
+        self._build_plot_toggles()
+        self.targeted_qc = TargetedQcWidget()
+
+        if self.analysis_mode is AnalysisMode.UNLABELLED:
+            self.isotopologue_ratios = None
+            self.total_abundance = None
+            self._assemble_unlabelled()
+        else:
+            self.isotopologue_ratios = IsotopologueRatioWidget()
+            self.total_abundance = TotalAbundanceWidget()
+            self._assemble_labelled()
+
+    def _checkbox_stylesheet(self, compact: bool) -> str:
+        checkmark_path = resource_path("resources", "checkmark.svg").replace("\\", "/")
+        padding = "2px 4px" if compact else "10px 8px"
+        return f"""
+            QCheckBox {{
+                background-color: transparent;
+                color: black;
+                spacing: 6px;
+                padding: {padding};
+                border: none;
+            }}
+            QCheckBox::indicator {{
+                width: 16px;
+                height: 16px;
+                border: none;
+                border-radius: 3px;
+                background-color: #e9ecef;
+            }}
+            QCheckBox::indicator:checked {{
+                background-color: #0d6efd;
+                image: url({checkmark_path});
+            }}
+            QCheckBox::indicator:hover {{
+                background-color: #d0d0d0;
+            }}
+        """
+
+    def _build_plot_toggles(self):
+        compact = self.analysis_mode is AnalysisMode.UNLABELLED
+        stylesheet = self._checkbox_stylesheet(compact)
+
+        self.baseline_checkbox = QCheckBox("Baseline correction")
+        self.baseline_checkbox.setObjectName("baseline_correction_checkbox")
+        self.baseline_checkbox.setToolTip(
+            "Enable linear baseline subtraction for this compound.\n"
+            "Fits a line through 3 points at each edge of the integration window\n"
+            "and subtracts the area under this baseline from the peak area."
+        )
+        self.baseline_checkbox.stateChanged.connect(self._on_baseline_checkbox_toggled)
+        self.baseline_checkbox.setStyleSheet(stylesheet)
+
+        self.shared_yscale_checkbox = QCheckBox("Shared y-scale")
+        self.shared_yscale_checkbox.setObjectName("shared_yscale_checkbox")
+        self.shared_yscale_checkbox.setToolTip(
+            "Use one common intensity scale for all sample plots.\n"
+            "Off: each plot autoscales to its own tallest peak."
+        )
+        self.shared_yscale_checkbox.setStyleSheet(stylesheet)
+        self.shared_yscale_checkbox.stateChanged.connect(
+            lambda state: self.shared_y_scale_toggled.emit(state != 0)
+        )
+
+        self.targeted_trace_normalization_checkbox = QCheckBox("Normalize Q/V shapes")
+        self.targeted_trace_normalization_checkbox.setObjectName(
+            "targeted_trace_normalization_checkbox"
+        )
+        self.targeted_trace_normalization_checkbox.setToolTip(
+            "Scale each V-ion trace to the Q-ion peak height so their chromatographic "
+            "shapes and apex alignment can be compared visually.\n"
+            "Display only: integration and exported areas always use the original signals."
+        )
+        self.targeted_trace_normalization_checkbox.setStyleSheet(stylesheet)
+        self.targeted_trace_normalization_checkbox.stateChanged.connect(
+            lambda state: self.targeted_trace_normalization_toggled.emit(state != 0)
+        )
+
+    def _section_label(self, text: str) -> QLabel:
+        label = QLabel(text)
+        label.setStyleSheet(
+            "color: #334155; font-size: 11px; font-weight: 600; "
+            "background-color: transparent; border: none;"
+        )
+        return label
+
+    def _quiet_status_label(self, object_name: str, text: str) -> QLabel:
+        label = QLabel(text)
+        label.setObjectName(object_name)
+        label.setStyleSheet(
+            "color: #64748b; font-size: 11px; background-color: transparent; border: none;"
+        )
+        return label
+
+    def _build_status_strip(self) -> QWidget:
+        strip = QWidget()
+        strip.setObjectName("unlabelledStatusStrip")
+        layout = QHBoxLayout(strip)
+        layout.setContentsMargins(0, 0, 2, 2)
+        layout.setSpacing(10)
+
+        self.load_status_label = self._quiet_status_label(
+            "unlabelledLoadStatus", ""
+        )
+        self.is_status_label = self._quiet_status_label("unlabelledIsStatus", "IS —")
+        self.mz_indicator = self._quiet_status_label(
+            "unlabelledIonStatus", "Q-ion m/z —"
+        )
+        self._refresh_load_status(False, False)
+        self._refresh_is_status()
+
+        layout.addWidget(self.load_status_label, 0)
+        layout.addWidget(self.is_status_label, 0)
+        layout.addStretch(1)
+        layout.addWidget(self.mz_indicator, 0)
+        return strip
+
+    def _assemble_unlabelled(self):
+        spec = self._layout_spec
+        self.standard.hide()
+        self.loaded_data.hide()
+        self.baseline_checkbox.setText("Baseline")
+        self.shared_yscale_checkbox.setText("Shared y-scale")
+        self.targeted_trace_normalization_checkbox.setText("Normalize Q/V")
+
+        self.sample_list.setMaximumHeight(spec.list_max_height)
+        self.compound_list.setMaximumHeight(spec.list_max_height)
+        self.integration.setMinimumWidth(0)
+
+        session = QWidget()
+        session_layout = QVBoxLayout(session)
+        session_layout.setContentsMargins(10, 10, 10, 8)
+        session_layout.setSpacing(6)
+        session_layout.addWidget(self._build_status_strip(), 0)
+        session_layout.addWidget(self._section_label("Samples"), 0)
+        session_layout.addWidget(self.sample_list, 0)
+        session_layout.addWidget(self._section_label("Compounds"), 0)
+        session_layout.addWidget(self.compound_list, 0)
+        session_layout.addWidget(self.integration, 0)
+
+        toggles = QWidget()
+        toggles.setObjectName("plotToggleStrip")
+        toggle_grid = QGridLayout(toggles)
+        toggle_grid.setContentsMargins(0, 0, 0, 0)
+        toggle_grid.setHorizontalSpacing(10)
+        toggle_grid.setVerticalSpacing(2)
+        for checkbox in (
+            self.baseline_checkbox,
+            self.shared_yscale_checkbox,
+            self.targeted_trace_normalization_checkbox,
+        ):
+            checkbox.setSizePolicy(
+                QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed
+            )
+        toggle_grid.addWidget(self.baseline_checkbox, 0, 0)
+        toggle_grid.addWidget(self.shared_yscale_checkbox, 0, 1)
+        toggle_grid.addWidget(
+            self.targeted_trace_normalization_checkbox, 1, 0, 1, 2
+        )
+        session_layout.addWidget(toggles, 0)
+        session_layout.addStretch(1)
+
+        session_scroll = QScrollArea()
+        session_scroll.setWidgetResizable(True)
+        session_scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        session_scroll.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        session_scroll.setFrameShape(QFrame.NoFrame)
+        session_scroll.setSizePolicy(
+            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred
+        )
+        session_scroll.setWidget(session)
+
+        self.targeted_qc.setMinimumHeight(spec.qc_min_height)
+        self.targeted_qc.setSizePolicy(
+            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding
+        )
+
+        splitter = QSplitter(Qt.Orientation.Vertical)
+        splitter.setObjectName("unlabelledToolbarSplitter")
+        splitter.addWidget(session_scroll)
+        splitter.addWidget(self.targeted_qc)
+        splitter.setCollapsible(1, False)
+        session_share = 1.0 - spec.qc_split_share
+        splitter.setStretchFactor(0, int(round(session_share * 100)))
+        splitter.setStretchFactor(1, int(round(spec.qc_split_share * 100)))
+        default_total = 900
+        qc_size = max(spec.qc_min_height, int(default_total * spec.qc_split_share))
+        splitter.setSizes([default_total - qc_size, qc_size])
+
+        main_layout = QVBoxLayout(self)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+        main_layout.addWidget(splitter)
+        self.setMinimumWidth(spec.toolbar_min_width)
+
+    def _assemble_labelled(self):
         container = QWidget()
         container.setStyleSheet("""
             QWidget {
@@ -77,7 +276,6 @@ class Toolbar(QWidget):
         container_layout = QVBoxLayout(container)
         container_layout.setContentsMargins(0, 0, 0, 0)
 
-        # Scroll area handles overflow on smaller screens
         scroll_area = QScrollArea()
         scroll_area.setWidgetResizable(True)
         scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
@@ -107,16 +305,12 @@ class Toolbar(QWidget):
             }
         """)
 
-        # Content widget holds all toolbar elements
         content_widget = QWidget()
         content_layout = QVBoxLayout(content_widget)
         content_layout.setContentsMargins(10, 10, 10, 10)
         content_layout.setSpacing(8)
 
-        # Group indicators together in a compact container
-        # Minimize vertical space while maintaining visual grouping
         indicators_container = QWidget()
-        # Remove any border styling from the container
         indicators_container.setStyleSheet("""
             QWidget {
                 border: none;
@@ -124,21 +318,16 @@ class Toolbar(QWidget):
             }
         """)
         indicators_layout = QVBoxLayout(indicators_container)
-        indicators_layout.setContentsMargins(2, 2, 2, 2)  # Minimal padding
-        indicators_layout.setSpacing(4)  # Reduced spacing between indicators
+        indicators_layout.setContentsMargins(2, 2, 2, 2)
+        indicators_layout.setSpacing(4)
         indicators_layout.setAlignment(
             Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignHCenter
         )
 
-        self.loaded_data = LoadedDataWidget()
         indicators_layout.addWidget(
             self.loaded_data, alignment=Qt.AlignmentFlag.AlignCenter
         )
-
-        # Add extra vertical spacing between data indicators and standard indicator
-        indicators_layout.addSpacing(8)  # Additional spacing
-
-        self.standard = StandardIndicator()
+        indicators_layout.addSpacing(8)
         indicators_layout.addWidget(
             self.standard, alignment=Qt.AlignmentFlag.AlignCenter
         )
@@ -154,135 +343,60 @@ class Toolbar(QWidget):
             self.mz_indicator, alignment=Qt.AlignmentFlag.AlignCenter
         )
 
-        # Compact the container to fit content size
         indicators_container.setMaximumHeight(
             self.loaded_data.sizeHint().height()
             + self.standard.sizeHint().height()
             + self.mz_indicator.sizeHint().height()
-            + 24  # Account for margins, spacing, and extra vertical gap
+            + 24
         )
-
-        # Add the container to the main layout with no stretch
         content_layout.addWidget(indicators_container, stretch=0)
 
-        self.sample_list = SampleListWidget()
-        content_layout.addWidget(
-            self.sample_list, stretch=1
-        )  # Give sample list more space
-
-        self.compound_list = CompoundListWidget()
-        content_layout.addWidget(
-            self.compound_list, stretch=1
-        )  # Give compound list more space
-
-        self.integration = IntegrationWindow(self.analysis_mode)
-        content_layout.addWidget(
-            self.integration, stretch=0
-        )  # No stretch for integration window
-
-        # Baseline correction checkbox (between integration window and plots)
-        self.baseline_checkbox = QCheckBox("Baseline correction")
-        self.baseline_checkbox.setObjectName("baseline_correction_checkbox")
-        self.baseline_checkbox.setToolTip(
-            "Enable linear baseline subtraction for this compound.\n"
-            "Fits a line through 3 points at each edge of the integration window\n"
-            "and subtracts the area under this baseline from the peak area."
-        )
-        self.baseline_checkbox.stateChanged.connect(self._on_baseline_checkbox_toggled)
-        # Apply checkbox styling
-        checkmark_path = resource_path("resources", "checkmark.svg").replace("\\", "/")
-        self.baseline_checkbox.setStyleSheet(f"""
-            QCheckBox {{
-                background-color: transparent;
-                color: black;
-                spacing: 8px;
-                padding: 10px 8px;
-            }}
-            QCheckBox::indicator {{
-                width: 16px;
-                height: 16px;
-                border: none;
-                border-radius: 3px;
-                background-color: #e9ecef;
-            }}
-            QCheckBox::indicator:checked {{
-                background-color: #0d6efd;
-                image: url({checkmark_path});
-            }}
-            QCheckBox::indicator:hover {{
-                background-color: #d0d0d0;
-            }}
-        """)
+        content_layout.addWidget(self.sample_list, stretch=1)
+        content_layout.addWidget(self.compound_list, stretch=1)
+        content_layout.addWidget(self.integration, stretch=0)
         content_layout.addWidget(self.baseline_checkbox, stretch=0)
-
-        # Shared y-scale toggle: one common scale across all sample tiles so
-        # abundances are visually comparable (off = per-tile autoscaling).
-        self.shared_yscale_checkbox = QCheckBox("Shared y-scale")
-        self.shared_yscale_checkbox.setObjectName("shared_yscale_checkbox")
-        self.shared_yscale_checkbox.setToolTip(
-            "Use one common intensity scale for all sample plots.\n"
-            "Off: each plot autoscales to its own tallest peak."
-        )
-        self.shared_yscale_checkbox.setStyleSheet(self.baseline_checkbox.styleSheet())
-        self.shared_yscale_checkbox.stateChanged.connect(
-            lambda state: self.shared_y_scale_toggled.emit(state != 0)
-        )
         content_layout.addWidget(self.shared_yscale_checkbox, stretch=0)
-
-        self.targeted_trace_normalization_checkbox = QCheckBox("Normalize Q/V shapes")
-        self.targeted_trace_normalization_checkbox.setObjectName(
-            "targeted_trace_normalization_checkbox"
-        )
-        self.targeted_trace_normalization_checkbox.setToolTip(
-            "Scale each V-ion trace to the Q-ion peak height so their chromatographic "
-            "shapes and apex alignment can be compared visually.\n"
-            "Display only: integration and exported areas always use the original signals."
-        )
-        self.targeted_trace_normalization_checkbox.setStyleSheet(
-            self.baseline_checkbox.styleSheet()
-        )
-        self.targeted_trace_normalization_checkbox.stateChanged.connect(
-            lambda state: self.targeted_trace_normalization_toggled.emit(state != 0)
-        )
         content_layout.addWidget(
             self.targeted_trace_normalization_checkbox, stretch=0
         )
-
-        self.isotopologue_ratios = IsotopologueRatioWidget()
-        content_layout.addWidget(
-            self.isotopologue_ratios, stretch=2
-        )  # Increased stretch for plots
-
-        self.total_abundance = TotalAbundanceWidget()
-        content_layout.addWidget(
-            self.total_abundance, stretch=2
-        )  # Increased stretch for plots
-
-        self.targeted_qc = TargetedQcWidget()
+        content_layout.addWidget(self.isotopologue_ratios, stretch=2)
+        content_layout.addWidget(self.total_abundance, stretch=2)
         content_layout.addWidget(self.targeted_qc, stretch=1)
 
-        if self.analysis_mode is AnalysisMode.UNLABELLED:
-            self.isotopologue_ratios.hide()
-            self.total_abundance.hide()
-        else:
-            self.targeted_qc.hide()
-            self.targeted_trace_normalization_checkbox.hide()
+        self.targeted_qc.hide()
+        self.targeted_trace_normalization_checkbox.hide()
 
         scroll_area.setWidget(content_widget)
         container_layout.addWidget(scroll_area)
 
-        main_layout = QVBoxLayout()
+        main_layout = QVBoxLayout(self)
         main_layout.setContentsMargins(0, 0, 0, 0)
         main_layout.addWidget(container)
-
-        # Wide enough that the unlabelled targeted-QC table fits without
-        # horizontal scrolling; the splitter still allows widening.
         self.setMinimumWidth(256)
 
-        self.setLayout(main_layout)
+    def _apply_unlabelled_splitter_sizes(self):
+        splitter = self.findChild(QSplitter, "unlabelledToolbarSplitter")
+        if splitter is None:
+            return
+        spec = self._layout_spec
+        total = splitter.height() or self.height()
+        if total <= 0:
+            return
+        qc_size = max(spec.qc_min_height, int(total * spec.qc_split_share))
+        session_size = max(1, total - qc_size)
+        splitter.setSizes([session_size, qc_size])
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        if (
+            self.analysis_mode is AnalysisMode.UNLABELLED
+            and not self._unlabelled_sizes_applied
+            and self.height() > 0
+        ):
+            self._apply_unlabelled_splitter_sizes()
+            self._unlabelled_sizes_applied = True
 
     def _connect_signals(self):
-        """Connect child widget signals to toolbar signal handlers"""
         self.sample_list.itemSelectionChanged.connect(self.on_samples_selection_changed)
         self.compound_list.itemSelectionChanged.connect(
             self.on_compound_selection_changed
@@ -298,12 +412,7 @@ class Toolbar(QWidget):
         self.sample_list.samples_deleted.connect(self.samples_deleted.emit)
         self.sample_list.samples_restored.connect(self.samples_restored.emit)
 
-    # --- Signal Handlers ---
     def on_samples_selection_changed(self):
-        """
-        Handler for when the selection changes in the samples list widget.
-        Emits the custom signal with the selected samples.
-        """
         selected_items = self.sample_list.selectedItems()
         if selected_items:
             selected_samples = [item.text() for item in selected_items]
@@ -312,89 +421,91 @@ class Toolbar(QWidget):
             self.samples_selected.emit([])
 
     def on_compound_selection_changed(self):
-        """
-        Handler for when the selection changes in the compounds list widget.
-        Emits the custom signal with the selected compound.
-        """
         selected_items = self.compound_list.selectedItems()
         if selected_items:
             selected_text = selected_items[0].text()
             self.compound_selected.emit(selected_text)
             self._set_mz_indicator_from_compound(selected_text)
-            # Initial fill - will be updated by plot selection logic after plotting
-            self.fill_integration_window(selected_text)
-            # Update baseline checkbox state
             self._set_baseline_checkbox_from_compound(selected_text)
         else:
             self.compound_selected.emit("")
-            self.mz_indicator.setText("m/z - --")
-
-
+            if self.analysis_mode is AnalysisMode.UNLABELLED:
+                self.mz_indicator.setText("Q-ion m/z —")
+            else:
+                self.mz_indicator.setText("m/z - --")
 
     def on_internal_standard_selected(self, compound_name: str):
-        """
-        Handler for when a compound is selected as internal standard.
-        Updates the standard indicator widget and emits signal.
-        """
         self.standard.set_internal_standard(compound_name)
+        self._refresh_is_status()
         self.internal_standard_selected.emit(compound_name)
 
-    # --- Public Methods ---
     def update_label_colours(self, raw_data_loaded, compound_list_loaded):
-        """Update the status indicators via the LoadedDataWidget"""
         self.loaded_data.update_status(raw_data_loaded, compound_list_loaded)
+        self._refresh_load_status(raw_data_loaded, compound_list_loaded)
 
     def update_compound_list(self, compounds: List[str]):
-        """Update the compounds list widget"""
         self.compound_list.update_compounds(compounds)
         self._set_mz_indicator_from_compound(self.get_selected_compound())
 
     def update_sample_list(self, samples: List[str]):
-        """Update the samples list widget"""
         self.sample_list.update_samples(samples)
 
     def get_selected_samples(self):
-        """
-        Get the currently selected samples without emitting signals.
-        Avoid infinite recursion via signals.
-        Returns a list of strings.
-        """
         selected_items = self.sample_list.selectedItems()
         if selected_items:
             return [item.text() for item in selected_items]
-        else:
-            return []
+        return []
 
     def get_selected_compound(self):
-        """
-        Get the currently selected compound without emitting signals.
-        Avoid infinite recursion via signals.
-        Returns a string.
-        """
         selected_items = self.compound_list.selectedItems()
         if selected_items:
             return selected_items[0].text()
-        else:
-            return ""
+        return ""
 
     def get_internal_standard(self):
-        """
-        Get the currently selected internal standard.
-        Returns the compound name or None if no standard is selected.
-        """
         return self.standard.internal_standard
 
-    def fill_integration_window(self, compound_name: str):
-        """
-        Legacy method - no longer used.
+    def clear_internal_standard(self):
+        self.standard.clear_internal_standard()
+        self._refresh_is_status()
 
-        Integration window fields are now populated by populate_fields_from_plots()
-        which properly handles session data overrides. This method previously
-        populated fields with base compound data, overwriting session values.
-        """
-        pass
+    def _refresh_load_status(self, raw_loaded: bool, compounds_loaded: bool) -> None:
+        if self.load_status_label is None:
+            return
+        raw = "●" if raw_loaded else "○"
+        compounds = "●" if compounds_loaded else "○"
+        self.load_status_label.setText(f"{raw} Raw  {compounds} Compounds")
+
+    def _refresh_is_status(self) -> None:
+        if self.is_status_label is None:
+            return
+        name = self.standard.internal_standard
+        if name:
+            self.is_status_label.setText(f"IS {name}")
+            self.is_status_label.setStyleSheet(
+                "color: #334155; font-size: 11px; "
+                "background-color: transparent; border: none;"
+            )
+        else:
+            self.is_status_label.setText("IS —")
+            self.is_status_label.setStyleSheet(
+                "color: #94a3b8; font-size: 11px; "
+                "background-color: transparent; border: none;"
+            )
 
     def _set_mz_indicator_from_compound(self, compound_name: str) -> None:
+        if self.analysis_mode is AnalysisMode.UNLABELLED:
+            empty = "Q-ion m/z —"
+            try:
+                comp = read_compound(compound_name)
+                channels = comp.analysis_channels
+                if channels:
+                    self.mz_indicator.setText(f"Q-ion m/z {channels[0].mz:g}")
+                else:
+                    self.mz_indicator.setText(empty)
+            except Exception:
+                self.mz_indicator.setText(empty)
+            return
         try:
             comp = read_compound(compound_name)
             self.mz_indicator.setText(f"m/z - {comp.mass0}")
@@ -402,7 +513,6 @@ class Toolbar(QWidget):
             self.mz_indicator.setText("m/z - --")
 
     def _set_baseline_checkbox_from_compound(self, compound_name: str):
-        """Set baseline correction checkbox state from compound data."""
         try:
             comp = read_compound(compound_name)
             enabled = bool(getattr(comp, "baseline_correction", 0))
@@ -415,7 +525,6 @@ class Toolbar(QWidget):
             self.baseline_checkbox.blockSignals(False)
 
     def _on_baseline_checkbox_toggled(self, state: int):
-        """Handle baseline correction checkbox toggle - update DB and emit signal."""
         compound_name = self.get_selected_compound()
         if not compound_name:
             return
@@ -442,6 +551,5 @@ class Toolbar(QWidget):
             self._set_baseline_checkbox_from_compound(compound_name)
 
     def on_internal_standard_cleared(self):
-        """Handler for clearing the internal standard."""
-        self.standard.clear_internal_standard()  # Calls existing method
-        self.internal_standard_selected.emit(None)  # Notify MainWindow standard is gone
+        self.clear_internal_standard()
+        self.internal_standard_selected.emit(None)

--- a/src/manic/ui/main_window.py
+++ b/src/manic/ui/main_window.py
@@ -2490,7 +2490,6 @@ class MainWindow(QMainWindow):
                 progress.setLabelText("Clearing visual elements...")
                 QCoreApplication.processEvents()
 
-                # Clear visual elements immediately
                 self.graph_view.clear_all_plots()
                 if self.toolbar.isotopologue_ratios is not None:
                     self.toolbar.isotopologue_ratios._clear_chart()
@@ -2499,22 +2498,18 @@ class MainWindow(QMainWindow):
                 if self.toolbar.targeted_qc is not None:
                     self.toolbar.targeted_qc.clear()
 
-                # Force UI update to show cleared graphs
                 self.graph_view.repaint()
 
                 progress.setValue(30)
                 progress.setLabelText("Clearing data lists...")
                 QCoreApplication.processEvents()
 
-                # Clear data lists
                 self.toolbar.update_compound_list([])
                 self.toolbar.update_sample_list([])
                 self.toolbar.update_label_colours(False, False)
 
-                # Clear internal standard
                 self.toolbar.clear_internal_standard()
 
-                # Clear integration window
                 self.toolbar.integration.populate_fields(None)
 
                 progress.setValue(40)

--- a/src/manic/ui/main_window.py
+++ b/src/manic/ui/main_window.py
@@ -2492,8 +2492,12 @@ class MainWindow(QMainWindow):
 
                 # Clear visual elements immediately
                 self.graph_view.clear_all_plots()
-                self.toolbar.isotopologue_ratios._clear_chart()
-                self.toolbar.total_abundance._clear_chart()
+                if self.toolbar.isotopologue_ratios is not None:
+                    self.toolbar.isotopologue_ratios._clear_chart()
+                if self.toolbar.total_abundance is not None:
+                    self.toolbar.total_abundance._clear_chart()
+                if self.toolbar.targeted_qc is not None:
+                    self.toolbar.targeted_qc.clear()
 
                 # Force UI update to show cleared graphs
                 self.graph_view.repaint()
@@ -2508,7 +2512,7 @@ class MainWindow(QMainWindow):
                 self.toolbar.update_label_colours(False, False)
 
                 # Clear internal standard
-                self.toolbar.standard.clear_internal_standard()
+                self.toolbar.clear_internal_standard()
 
                 # Clear integration window
                 self.toolbar.integration.populate_fields(None)

--- a/src/manic/ui/targeted_qc_widget.py
+++ b/src/manic/ui/targeted_qc_widget.py
@@ -104,8 +104,6 @@ class TargetedQcWidget(QWidget):
         self.table.setSelectionMode(QAbstractItemView.NoSelection)
         self.table.setFocusPolicy(Qt.NoFocus)
         self.table.setShowGrid(True)
-        # Fit the sidebar: never scroll horizontally; elide long sample names
-        # (full names remain available in tooltips).
         self.table.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.table.setTextElideMode(Qt.ElideMiddle)
         self.table.setStyleSheet(

--- a/src/manic/ui/targeted_qc_widget.py
+++ b/src/manic/ui/targeted_qc_widget.py
@@ -9,6 +9,7 @@ from PySide6.QtWidgets import (
     QCheckBox,
     QHeaderView,
     QLabel,
+    QSizePolicy,
     QTableWidget,
     QTableWidgetItem,
     QVBoxLayout,
@@ -57,12 +58,13 @@ class TargetedQcWidget(QWidget):
 
     def __init__(self, parent=None):
         super().__init__(parent)
+        self.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Expanding)
         layout = QVBoxLayout(self)
         layout.setContentsMargins(4, 4, 4, 4)
         layout.setSpacing(4)
 
         self.title = QLabel("Targeted identity QC")
-        self.title.setStyleSheet("font-weight: 600; color: #15324b;")
+        self.title.setStyleSheet("font-weight: 600; color: #15324b; font-size: 11px;")
         layout.addWidget(self.title)
 
         self.summary = QLabel("")
@@ -97,7 +99,7 @@ class TargetedQcWidget(QWidget):
         self.table = QTableWidget(0, 4)
         self.observed_retention_times: dict[str, float] = {}
         self.table.verticalHeader().setVisible(False)
-        self.table.verticalHeader().setDefaultSectionSize(20)
+        self.table.verticalHeader().setDefaultSectionSize(22)
         self.table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.table.setSelectionMode(QAbstractItemView.NoSelection)
         self.table.setFocusPolicy(Qt.NoFocus)
@@ -107,9 +109,9 @@ class TargetedQcWidget(QWidget):
         self.table.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.table.setTextElideMode(Qt.ElideMiddle)
         self.table.setStyleSheet(
-            "QTableWidget { font-size: 10px; gridline-color: #e3e9ee; }"
+            "QTableWidget { font-size: 11px; gridline-color: #e3e9ee; }"
             "QHeaderView::section { background-color: #eef3f7; color: #15324b;"
-            " font-size: 10px; padding: 1px; border: none; }"
+            " font-size: 11px; padding: 1px; border: none; }"
         )
         self.table.horizontalHeader().setSectionResizeMode(
             0, QHeaderView.Stretch
@@ -124,7 +126,7 @@ class TargetedQcWidget(QWidget):
         self.details.setStyleSheet(
             "background-color: #f5f8fa; color: #334155; "
             "border: 1px solid #d7e0e7; border-radius: 4px; padding: 5px; "
-            "font-size: 10px;"
+            "font-size: 11px;"
         )
         self.details.hide()
         layout.addWidget(self.details)

--- a/tests/test_ui_formatting.py
+++ b/tests/test_ui_formatting.py
@@ -8,7 +8,7 @@ and other UI components.
 import pytest
 from PySide6.QtCharts import QChart, QValueAxis
 from PySide6.QtCore import Qt
-from PySide6.QtWidgets import QApplication, QLabel
+from PySide6.QtWidgets import QApplication, QLabel, QSplitter
 import sys
 import numpy as np
 from types import SimpleNamespace
@@ -55,11 +55,25 @@ def integration_window(qapp):
 def test_unlabelled_toolbar_hides_label_derived_summaries(qapp):
     toolbar = Toolbar(AnalysisMode.UNLABELLED)
     try:
-        assert toolbar.isotopologue_ratios.isHidden()
-        assert toolbar.total_abundance.isHidden()
+        assert toolbar.isotopologue_ratios is None
+        assert toolbar.total_abundance is None
         assert not toolbar.targeted_qc.isHidden()
         assert not toolbar.targeted_trace_normalization_checkbox.isHidden()
         assert toolbar.integration.findChild(QLabel, "reference_rt_note") is None
+    finally:
+        toolbar.deleteLater()
+
+
+def test_unlabelled_toolbar_qc_pane_geometry(qapp):
+    toolbar = Toolbar(AnalysisMode.UNLABELLED)
+    try:
+        toolbar.setAttribute(Qt.WidgetAttribute.WA_DontShowOnScreen, True)
+        toolbar.resize(280, 900)
+        toolbar.show()
+        QApplication.processEvents()
+        assert toolbar.targeted_qc.height() >= 240
+        splitter = toolbar.findChild(QSplitter, "unlabelledToolbarSplitter")
+        assert splitter is not None
     finally:
         toolbar.deleteLater()
 


### PR DESCRIPTION
Unlabelled mode was still the labelled left column with the charts hidden. Identity QC sat at the bottom of a scroll stack and measured about 150px on a 900px pane.

The unlabelled toolbar is now a vertical splitter. Session controls stay compact on top. The QC table owns a reserved pane (260px floor, 377px at 280x900). Status pills and the red unused-standard alarm are gone. Integration is two rows. Reset is a quiet secondary action. Labelled mode still builds its scroll stack and charts.

48 tests in `test_ui_formatting.py` and `test_analysis_mode.py`. Offscreen grabs at 280x900 confirm the QC pane stays usable.